### PR TITLE
Ignore max-line-length lint errors

### DIFF
--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -3,5 +3,5 @@ import * as path from "path";
 $injector.require("nsStarterKitsGitService", path.join(__dirname, "services", "nsStarterKitsGitService"));
 $injector.require("nsStarterKitsNpmService", path.join(__dirname, "services", "nsStarterKitsNpmService"));
 $injector.require("nsStarterKitsPageService", path.join(__dirname, "services", "nsStarterKitsPageService"));
-$injector.requirePublicClass("nsStarterKitsTemplateService", path.join(__dirname, "services", "nsStarterKitsTemplateService"));
-$injector.requirePublicClass("nsStarterKitsApplicationService", path.join(__dirname, "services", "nsStarterKitsApplicationService"));
+$injector.requirePublicClass("nsStarterKitsTemplateService", path.join(__dirname, "services", "nsStarterKitsTemplateService")); // tslint:disable-line:max-line-length
+$injector.requirePublicClass("nsStarterKitsApplicationService", path.join(__dirname, "services", "nsStarterKitsApplicationService")); // tslint:disable-line:max-line-length

--- a/lib/services/nsStarterKitsPageService.ts
+++ b/lib/services/nsStarterKitsPageService.ts
@@ -36,7 +36,7 @@ export class NsStarterKitsPageService implements INsStarterKitsPageService {
                         return Promise.reject(new Error(`Page with the name "${pageName}" already exists`));
                     }
 
-                    return this.$nsStarterKitsNpmService.installPageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory);
+                    return this.$nsStarterKitsNpmService.installPageTemplate(displayName, pageTemplate.templateFlavor, pagesDirectory); // tslint:disable-line:max-line-length
                 })
                 .then((downloadPath: any) => {
                     return this.createPage(downloadPath, newPageDirectory, pageName);


### PR DESCRIPTION
Disabled the specific max-line-length tslint errors that are failing.

It is better not to get used to having the linter "red" as we can miss some important error like that. 